### PR TITLE
Added windows GPU vendor logic.

### DIFF
--- a/cloudmesh/gpu/gpu.py
+++ b/cloudmesh/gpu/gpu.py
@@ -1,5 +1,6 @@
 import xmltodict
 from cloudmesh.common.Shell import Shell
+import os
 import yaml
 
 class Gpu:
@@ -8,11 +9,18 @@ class Gpu:
         pass
 
     def vendor(self):
-        try:
-            r = Shell.run("lspci -vnn | grep VGA -A 12 | fgrep Subsystem:").strip()
-            result = r.split("Subsystem:")[1]
-        except:
-            result = None
+        if os.name != "nt":
+            try:
+                r = Shell.run("lspci -vnn | grep VGA -A 12 | fgrep Subsystem:").strip()
+                result = r.split("Subsystem:")[1]
+            except:
+                result = None
+        else:
+            try:
+                r = Shell.run("wmic path win32_VideoController get AdapterCompatibility").strip()
+                result = [x.strip() for x in r.split("\r\r\n")[1:]]
+            except Exception:
+                results = None
         return result
 
 


### PR DESCRIPTION
Added the call to wmic to make the vendor command work on windows.  Note that if you have multiple graphics cards, it'll return each in the vendor field as an array.

Output on my machine when running:
```
cms gpu system
gpu system
{
  "product_name": "NVIDIA GeForce RTX 3080 Laptop GPU",
  "product_brand": "GeForce",
  "product_architecture": "Ampere",
  "vbios_version": "94.04.3e.00.9d",
  "inforom_version": {
    "img_version": "G001.0000.03.03",
    "oem_object": "2.0",
    "ecc_object": "N/A",
    "pwr_object": "N/A"
  },
  "accounted_processes": null,
  "vendor": [
    "NVIDIA",
    "Advanced Micro Devices, Inc."
  ]
}
Timer: 2.3269s Load: 0.0156s gpu system
```

Note that I have two GPUs in my laptop (discreet Nvidia and and integrated Radeon; the AMD is for the integrated chip).